### PR TITLE
[FIX] GET function name

### DIFF
--- a/sobit_mini_library/include/sobit_mini_library/sobit_mini_joint_action_server.hpp
+++ b/sobit_mini_library/include/sobit_mini_library/sobit_mini_joint_action_server.hpp
@@ -4,8 +4,8 @@
 #include "sobits_interfaces/action/move_to_pose.hpp"
 // #include "sobits_interfaces/action/move_hand_to_target_coord.hpp"
 // #include "sobits_interfaces/action/move_hand_to_target_tf.hpp"
-#include "sobits_interfaces/srv/move_hand_to_target_coord.hpp"
-#include "sobits_interfaces/srv/move_hand_to_target_tf.hpp"
+#include "sobits_interfaces/srv/get_hand_to_target_coord.hpp"
+#include "sobits_interfaces/srv/get_hand_to_target_tf.hpp"
 
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
@@ -72,8 +72,8 @@ public:
   using MoveToPose = sobits_interfaces::action::MoveToPose;
   // using MoveHandToTargetCoord = sobits_interfaces::action::MoveHandToTargetCoord;
   // using MoveHandToTargetTF = sobits_interfaces::action::MoveHandToTargetTF;
-  using MoveHandToTargetCoord = sobits_interfaces::srv::MoveHandToTargetCoord;
-  using MoveHandToTargetTF = sobits_interfaces::srv::MoveHandToTargetTF;
+  using GetHandToTargetCoord = sobits_interfaces::srv::GetHandToTargetCoord;
+  using GetHandToTargetTF = sobits_interfaces::srv::GetHandToTargetTF;
 
   using GoalHandleMoveJoints = rclcpp_action::ServerGoalHandle<sobits_interfaces::action::MoveJoint>;
   using GoalHandleMoveToPose = rclcpp_action::ServerGoalHandle<sobits_interfaces::action::MoveToPose>;
@@ -131,14 +131,14 @@ private:
 
   rclcpp_action::Server<MoveJoint>::SharedPtr action_server_move_joints_;
   rclcpp_action::Server<MoveToPose>::SharedPtr action_server_move_to_pose_;
-  rclcpp::Service<MoveHandToTargetCoord>::SharedPtr service_server_move_hand_to_coord_left_;
-  rclcpp::Service<MoveHandToTargetTF>::SharedPtr service_server_move_hand_to_tf_left_;
-  rclcpp::Service<MoveHandToTargetCoord>::SharedPtr service_server_move_hand_to_coord_right_;
-  rclcpp::Service<MoveHandToTargetTF>::SharedPtr service_server_move_hand_to_tf_right_;
-  rclcpp::Service<MoveHandToTargetCoord>::SharedPtr service_server_move_hand_to_coord_one_left_;
-  rclcpp::Service<MoveHandToTargetTF>::SharedPtr service_server_move_hand_to_tf_one_left_;
-  rclcpp::Service<MoveHandToTargetCoord>::SharedPtr service_server_move_hand_to_coord_one_right_;
-  rclcpp::Service<MoveHandToTargetTF>::SharedPtr service_server_move_hand_to_tf_one_right_;
+  rclcpp::Service<GetHandToTargetCoord>::SharedPtr service_server_get_hand_to_coord_left_;
+  rclcpp::Service<GetHandToTargetTF>::SharedPtr service_server_get_hand_to_tf_left_;
+  rclcpp::Service<GetHandToTargetCoord>::SharedPtr service_server_get_hand_to_coord_right_;
+  rclcpp::Service<GetHandToTargetTF>::SharedPtr service_server_get_hand_to_tf_right_;
+  rclcpp::Service<GetHandToTargetCoord>::SharedPtr service_server_get_hand_to_coord_one_left_;
+  rclcpp::Service<GetHandToTargetTF>::SharedPtr service_server_get_hand_to_tf_one_left_;
+  rclcpp::Service<GetHandToTargetCoord>::SharedPtr service_server_get_hand_to_coord_one_right_;
+  rclcpp::Service<GetHandToTargetTF>::SharedPtr service_server_get_hand_to_tf_one_right_;
 
   rclcpp_action::GoalResponse handle_move_joints_goal(const rclcpp_action::GoalUUID & uuid, std::shared_ptr<const MoveJoint::Goal> goal);
   rclcpp_action::GoalResponse handle_move_to_pose_goal(const rclcpp_action::GoalUUID & uuid, std::shared_ptr<const MoveToPose::Goal> goal);
@@ -151,8 +151,8 @@ private:
 
   void exe_move_joints(const std::shared_ptr<GoalHandleMoveJoints> goal_handle);
   void exe_move_to_pose(const std::shared_ptr<GoalHandleMoveToPose> goal_handle);
-  void serve_move_hand_to_coord(const std::shared_ptr<MoveHandToTargetCoord::Request> request, std::shared_ptr<MoveHandToTargetCoord::Response> response, bool is_right, bool is_one_rink);
-  void serve_move_hand_to_tf(const std::shared_ptr<MoveHandToTargetTF::Request> request, std::shared_ptr<MoveHandToTargetTF::Response> response, bool is_right, bool is_one_rink);
+  void serve_get_hand_to_coord(const std::shared_ptr<GetHandToTargetCoord::Request> request, std::shared_ptr<GetHandToTargetCoord::Response> response, bool is_right, bool is_one_rink);
+  void serve_get_hand_to_tf(const std::shared_ptr<GetHandToTargetTF::Request> request, std::shared_ptr<GetHandToTargetTF::Response> response, bool is_right, bool is_one_rink);
 
   rclcpp::Publisher<trajectory_msgs::msg::JointTrajectory>::SharedPtr pub_joint_control_;
   rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr sub_joint_state_;

--- a/sobit_mini_library/src/sobit_mini_joint_action_server.cpp
+++ b/sobit_mini_library/src/sobit_mini_joint_action_server.cpp
@@ -29,47 +29,47 @@ JointActionServer::JointActionServer(const rclcpp::NodeOptions & options = rclcp
 
 
   // default grasp mode
-  this->service_server_move_hand_to_coord_left_ = this->create_service<MoveHandToTargetCoord>(
-      "move_hand_to_coord/left",
-      [this](const std::shared_ptr<MoveHandToTargetCoord::Request> request, std::shared_ptr<MoveHandToTargetCoord::Response> response) {
-        serve_move_hand_to_coord(request, response, false, false);  // when target hand is left, 3rd arg is 'false'
+  this->service_server_get_hand_to_coord_left_ = this->create_service<GetHandToTargetCoord>(
+      "get_hand_to_coord/left",
+      [this](const std::shared_ptr<GetHandToTargetCoord::Request> request, std::shared_ptr<GetHandToTargetCoord::Response> response) {
+        serve_get_hand_to_coord(request, response, false, false);  // when target hand is left, 3rd arg is 'false'
       });
-  this->service_server_move_hand_to_tf_left_ = this->create_service<MoveHandToTargetTF>(
-      "move_hand_to_tf/left",
-      [this](const std::shared_ptr<MoveHandToTargetTF::Request> request, std::shared_ptr<MoveHandToTargetTF::Response> response) {
-        serve_move_hand_to_tf(request, response, false, false);  // when target hand is left, 3rd arg is 'false'
+  this->service_server_get_hand_to_tf_left_ = this->create_service<GetHandToTargetTF>(
+      "get_hand_to_tf/left",
+      [this](const std::shared_ptr<GetHandToTargetTF::Request> request, std::shared_ptr<GetHandToTargetTF::Response> response) {
+        serve_get_hand_to_tf(request, response, false, false);  // when target hand is left, 3rd arg is 'false'
       });
-  this->service_server_move_hand_to_coord_right_ = this->create_service<MoveHandToTargetCoord>(
-      "move_hand_to_coord/right",
-      [this](const std::shared_ptr<MoveHandToTargetCoord::Request> request, std::shared_ptr<MoveHandToTargetCoord::Response> response) {
-        serve_move_hand_to_coord(request, response, true, false);  // when target hand is right, 3rd arg is 'true'
+  this->service_server_get_hand_to_coord_right_ = this->create_service<GetHandToTargetCoord>(
+      "get_hand_to_coord/right",
+      [this](const std::shared_ptr<GetHandToTargetCoord::Request> request, std::shared_ptr<GetHandToTargetCoord::Response> response) {
+        serve_get_hand_to_coord(request, response, true, false);  // when target hand is right, 3rd arg is 'true'
       });
-  this->service_server_move_hand_to_tf_right_ = this->create_service<MoveHandToTargetTF>(
-      "move_hand_to_tf/right",
-      [this](const std::shared_ptr<MoveHandToTargetTF::Request> request, std::shared_ptr<MoveHandToTargetTF::Response> response) {
-        serve_move_hand_to_tf(request, response, true, false);  // when target hand is right, 3rd arg is 'true'
+  this->service_server_get_hand_to_tf_right_ = this->create_service<GetHandToTargetTF>(
+      "get_hand_to_tf/right",
+      [this](const std::shared_ptr<GetHandToTargetTF::Request> request, std::shared_ptr<GetHandToTargetTF::Response> response) {
+        serve_get_hand_to_tf(request, response, true, false);  // when target hand is right, 3rd arg is 'true'
       });
 
   // one link grasp mode
-  this->service_server_move_hand_to_coord_one_left_ = this->create_service<MoveHandToTargetCoord>(
-      "move_hand_to_coord/one_link/left",
-      [this](const std::shared_ptr<MoveHandToTargetCoord::Request> request, std::shared_ptr<MoveHandToTargetCoord::Response> response) {
-        serve_move_hand_to_coord(request, response, false, true);  // when target hand is left, 3rd arg is 'false'
+  this->service_server_get_hand_to_coord_one_left_ = this->create_service<GetHandToTargetCoord>(
+      "get_hand_to_coord/one_link/left",
+      [this](const std::shared_ptr<GetHandToTargetCoord::Request> request, std::shared_ptr<GetHandToTargetCoord::Response> response) {
+        serve_get_hand_to_coord(request, response, false, true);  // when target hand is left, 3rd arg is 'false'
       });
-  this->service_server_move_hand_to_tf_one_left_ = this->create_service<MoveHandToTargetTF>(
-      "move_hand_to_tf/one_link/left",
-      [this](const std::shared_ptr<MoveHandToTargetTF::Request> request, std::shared_ptr<MoveHandToTargetTF::Response> response) {
-        serve_move_hand_to_tf(request, response, false, true);  // when target hand is left, 3rd arg is 'false'
+  this->service_server_get_hand_to_tf_one_left_ = this->create_service<GetHandToTargetTF>(
+      "get_hand_to_tf/one_link/left",
+      [this](const std::shared_ptr<GetHandToTargetTF::Request> request, std::shared_ptr<GetHandToTargetTF::Response> response) {
+        serve_get_hand_to_tf(request, response, false, true);  // when target hand is left, 3rd arg is 'false'
       });
-  this->service_server_move_hand_to_coord_one_right_ = this->create_service<MoveHandToTargetCoord>(
-      "move_hand_to_coord/one_link/right",
-      [this](const std::shared_ptr<MoveHandToTargetCoord::Request> request, std::shared_ptr<MoveHandToTargetCoord::Response> response) {
-        serve_move_hand_to_coord(request, response, true, true);  // when target hand is right, 3rd arg is 'true'
+  this->service_server_get_hand_to_coord_one_right_ = this->create_service<GetHandToTargetCoord>(
+      "get_hand_to_coord/one_link/right",
+      [this](const std::shared_ptr<GetHandToTargetCoord::Request> request, std::shared_ptr<GetHandToTargetCoord::Response> response) {
+        serve_get_hand_to_coord(request, response, true, true);  // when target hand is right, 3rd arg is 'true'
       });
-  this->service_server_move_hand_to_tf_one_right_ = this->create_service<MoveHandToTargetTF>(
-      "move_hand_to_tf/one_link/right",
-      [this](const std::shared_ptr<MoveHandToTargetTF::Request> request, std::shared_ptr<MoveHandToTargetTF::Response> response) {
-        serve_move_hand_to_tf(request, response, true, true);  // when target hand is right, 3rd arg is 'true'
+  this->service_server_get_hand_to_tf_one_right_ = this->create_service<GetHandToTargetTF>(
+      "get_hand_to_tf/one_link/right",
+      [this](const std::shared_ptr<GetHandToTargetTF::Request> request, std::shared_ptr<GetHandToTargetTF::Response> response) {
+        serve_get_hand_to_tf(request, response, true, true);  // when target hand is right, 3rd arg is 'true'
       });
 
 
@@ -437,9 +437,9 @@ void JointActionServer::exe_move_to_pose(
   goal_handle->succeed(result);
 }
 
-void JointActionServer::serve_move_hand_to_coord(
-  const std::shared_ptr<MoveHandToTargetCoord::Request> request,
-  std::shared_ptr<MoveHandToTargetCoord::Response> response,
+void JointActionServer::serve_get_hand_to_coord(
+  const std::shared_ptr<GetHandToTargetCoord::Request> request,
+  std::shared_ptr<GetHandToTargetCoord::Response> response,
   bool is_right, bool is_one_rink)
 {
 
@@ -536,9 +536,9 @@ void JointActionServer::serve_move_hand_to_coord(
   return;
 }
 
-void JointActionServer::serve_move_hand_to_tf(
-  const std::shared_ptr<MoveHandToTargetTF::Request> request,
-  std::shared_ptr<MoveHandToTargetTF::Response> response,
+void JointActionServer::serve_get_hand_to_tf(
+  const std::shared_ptr<GetHandToTargetTF::Request> request,
+  std::shared_ptr<GetHandToTargetTF::Response> response,
   bool is_right, bool is_one_rink)
 {
 


### PR DESCRIPTION
Renamed the function from move_hand_to_target_coord to get_hand_to_target_coord because the function does not perform any motion. Instead, it computes and returns the joint values required to move the hand to the target coordinate.